### PR TITLE
Adds scapp.argv to documentation

### DIFF
--- a/docs/md/Window.md
+++ b/docs/md/Window.md
@@ -48,6 +48,8 @@ Instances of the Window class represent desktop windows.
   * `window.isEnabled` - read/write, boolean, true if the window is allowed to accept user's input.
   * `window.aspectRatio` - read/write, float, width to height ratio to keep on window resizes.
   * `window.eventRoot = element | null` - if set by element, short circuits all UI events to that element and its children as if the window contains only that element. Used in lightbox dialog scenarios (see: samples.sciter/lightbox-dialog).
+  * `scapp`
+    * `argv` - read-only, array of strings, contains command line arguments of Scitter App
 
 #### methods:
 


### PR DESCRIPTION
Sadly, I can't find in source code any more information, what all `scapp` object contains.
