### PR TITLE
fix: \samples.css\css++\mark.htm

### DIFF
--- a/samples.css/css++/mark.htm
+++ b/samples.css/css++/mark.htm
@@ -1,53 +1,58 @@
 <html>
-    <head>
-        <title>Test</title>
-        <style>
+  <head>
+    <title>Test</title>
+      <style>
 
-           textarea {
-             display:block;
-           }
+        textarea {
+          display:block;
+        }
 
-           textarea::mark(found) { 
-            color: brown; 
-            background-color:yellow;
-          }
+        textarea::mark(found) { 
+          color: brown; 
+          background-color:yellow;
+        }
 
-        </style>
-        <script type="text/tiscript">
+      </style>
+      <script>
 
-          var textToLookup = "bar"; 
+        var textToLookup = "bar"; 
 
-          function highlightFound(ta) 
+        function highlightFound(ta) 
+        {
+          const range = new Range();
+          var textNode = ta.firstChild; // getting text node of text area
+          var text = textNode.textContent;             
+          // clear mark 
           {
-             var textNode = ta.firstNode; // getting text node of text area
-             var text = textNode.text;             
-             // clear mark 
-             {
-               var bookmarkStart = [bookmark:textNode, 0, false];
-               var bookmarkEnd = [bookmark:textNode, text.length, false];
-               Selection.clearMark(bookmarkStart,bookmarkEnd,"found");
-             }
-             // apply mark to first found word if any
-             var pos = text.indexOf(textToLookup);
-             if( pos >= 0) {
-               var bookmarkStart = [bookmark:textNode, pos, false];
-               var bookmarkEnd = [bookmark:textNode, pos + textToLookup.length, false];
-               Selection.applyMark(bookmarkStart,bookmarkEnd,"found");
-             }
+            range.setStart(textNode, 0);
+            range.setEnd(textNode, text.length);
+            range.clearMark("found");
           }
+          // apply mark to first found word if any
+          var pos = text.indexOf(textToLookup);
+          if( pos >= 0) {
+            range.setStart(textNode, pos);
+            range.setEnd(textNode, pos + textToLookup.length);
+            range.applyMark("found");
+          }
+        }
 
-          // initial higlightion
-          highlightFound($(textarea));
+        // initial higlightion
+        highlightFound(document.$("textarea"));
+        
+        document.on("change","textarea", function(evt, ta) {
+          highlightFound(ta);
+        });
+          
+        document.on("change","input#what", function(evt, input) {
+          textToLookup = input.value; 
+          highlightFound(document.$("textarea"));
+        });
+      </script>
+  </head>
+  <body>
 
-          // on change higlightion
-          event change $(textarea) { highlightFound(this); }
-          event change $(input#what) { textToLookup = this.value; highlightFound($(textarea)); }
-
-        </script>
-    </head>
-    <body>
-
-<h2>Demo of CSS ::mark(name) pseudo-element styling</h2>
+  <h2>Demo of CSS ::mark(name) pseudo-element styling</h2>
 
      Text to lookup: <input|text #what value="bar" />
 


### PR DESCRIPTION
Some of the examples in \samples.css\ still uses `<script type="text/tiscript"></script>`, this is port of `\samples.css\css++\mark.htm` to Sciter.JS