### PR TITLE
element id is readonly

### DIFF
--- a/docs/md/Element.md
+++ b/docs/md/Element.md
@@ -4,7 +4,7 @@ class Element represents DOM element and extends [Node](Node.md) and so all its 
 
 ## Properties:
 
-* `element.id`
+* `element.id` - readonly
 * `element.elementIndex`
 * `element.tagName`
 * `element.tag` - lower case version of .tagName


### PR DESCRIPTION
I noticed that the element.id property is read only as in this example.

```
<html
    window-resizable="true"
    window-width="400dip"
    window-height="770dip"
>
<script>

document.ready = function() {
    // does not work
    document.body.id = "newbodyid";

    // works
    document.body.setAttribute("id", "newbodyid");
}

</script>
</head>
<body #bodyid>
</body>
</html>
```