### PR TITLE
inspector: copy/clear logs

### DIFF
--- a/demos/inspector/res/channel-log.js
+++ b/demos/inspector/res/channel-log.js
@@ -66,4 +66,29 @@ export class ChannelLog extends Element
     return false; // do not propagate, consumed
   }
 
+  list2clipboard() {
+    var text = "";
+    for(var opt of this.$$("li")) {
+      text += opt.textContent;
+    }  
+    Clipboard.writeText(text);
+  }
+
+  ["on keydown"] (evt) {
+    if( evt.code === "KeyC" && evt.ctrlKey) { 
+      this.list2clipboard(); 
+      return true; 
+    }
+  }
+  
+  ["on click at menu#for-log-list>li[command='edit:copy']"](evt, menu) { 
+    this.list2clipboard();
+    return true;
+  }
+  
+  ["on click at menu#for-log-list>li[command='edit:clear']"](evt, menu) {
+    this.channel.theirLogs = [];
+    this.componentUpdate();
+    return true;
+  }
 }

--- a/demos/inspector/res/facade.css
+++ b/demos/inspector/res/facade.css
@@ -101,7 +101,8 @@ section.tabs > header > caption { width:max-content; display:block; height:*; pa
        
 @set channel-log {
   :root {
-    font: system;
+    font: monospace, system;
+    context-menu: selector(menu#for-log-list);
   }
 
   list {


### PR DESCRIPTION
Individual rows of logs are not select-able right now like Sciter.TIS, so its just copies whole log.

Edit: also this commit changes the font of logs to monospace, logs of parser libs have exact column and row positioin errors which are not distinguishable in non monospace fonts.

