### PR TITLE
sample port to sciter.js

### DIFF
--- a/samples.css/css++/visibility-none.htm
+++ b/samples.css/css++/visibility-none.htm
@@ -3,9 +3,6 @@
     <title></title>
     <style>
     
-      @import "../../widgets/switch/switch.css";
-      
-      
       // visiblity rules:
       [for-mode] { visibility:none; /* same as display:none */ }
       
@@ -18,21 +15,22 @@
       html[mode='complete'] tr:not(.complete) { visibility:none; }
     
     </style>
-    <script type="text/tiscript">
+    <script>
     
-    self.on("change","switch", :: self.attributes["mode"] = this.value); 
-    
+    document.on("change", "select|switch", function(evt, select) {
+      document.setAttribute("mode", select.value);
+    });
     </script>
   </head>
 <body>
 
 <p>Click on the switch above</p>
 
-<switch>
+<select|switch>
     <option value="all">All</option>
     <option value="pending">Pending</option>
     <option value="complete">Complete</option>
-</switch>
+</select>
 
   <p for-mode="all pending complete" >Current mode is 
      <span for-mode="all">All</span><span for-mode="pending">Pending</span><span for-mode="complete">Complete</span></p>


### PR DESCRIPTION
This is port of `\samples.css\css++\visibility-none.htm` to Sciter.JS

also there seems to be a **bug** in css, for sample above if you switch to `pending` or `completed` and come back to `all`, it doesn't reflect the changes **until you maximize, minimize or restore the window**, the content gets updated only after restoring or minimizing the window when returning back to all from other options. (Also in TIS).