### PR TITLE
Inspector: fix eval input behavior

### DIFF
--- a/demos/inspector/res/channel-log.js
+++ b/demos/inspector/res/channel-log.js
@@ -63,6 +63,7 @@ export class ChannelLog extends Element
       items: [toeval]
     })
     this.channel.notify("toeval",toeval);
+    evt.preventDefault(); // prevents a new line in the eval input unless the user holds shift
     return false; // do not propagate, consumed
   }
 


### PR DESCRIPTION
When you press enter in the Inspector's eval textarea to run a snippet of code, the textarea goes to a new line in addition to running the code (unintended behavior). Calling `preventDefault` on the event prevents this behavior unless the user holds down the shift key