### PR TITLE
Fixes for generating up to date bindings for rust

### DIFF
--- a/include/sciter-om-def.h
+++ b/include/sciter-om-def.h
@@ -29,7 +29,7 @@ typedef SBOOL(*som_any_prop_setter_t)(som_asset_t* thing, UINT64 propSymbol, con
 typedef SBOOL(*som_method_t)(som_asset_t* thing, UINT argc, const SOM_VALUE* argv, SOM_VALUE* p_result);
 typedef void(*som_dispose_t)(som_asset_t* thing);
 
-struct som_property_def_t {
+typedef struct som_property_def_t {
   void*             reserved;
   som_atom_t        name;
   som_prop_getter_t getter;
@@ -37,9 +37,9 @@ struct som_property_def_t {
 #ifdef __cplusplus
   som_property_def_t(const char* n, som_prop_getter_t pg, som_prop_setter_t ps = nullptr) : name(SciterAtomValue(n)), getter(pg), setter(ps) {}
 #endif
-};
+} som_property_def_t;
 
-struct som_method_def_t {
+typedef struct som_method_def_t {
   void*        reserved;
   som_atom_t   name;
   size_t       params;
@@ -47,7 +47,7 @@ struct som_method_def_t {
 #ifdef __cplusplus
   som_method_def_t(const char* n, size_t p, som_method_t f) : name(SciterAtomValue(n)), params(p), func(f) {}
 #endif
-};
+} som_method_def_t;
 
 enum som_passport_flags {
   SOM_SEALED_OBJECT = 0x00,    // not extendable
@@ -56,7 +56,7 @@ enum som_passport_flags {
 
 // definiton of object (the thing) access interface
 // this structure should be statically allocated - at least survive last instance of the engine
-struct som_passport_t {
+typedef struct som_passport_t {
   UINT64             flags;
   som_atom_t         name;         // class name
   const som_property_def_t* properties; size_t n_properties; // virtual property thunks
@@ -67,7 +67,7 @@ struct som_passport_t {
   // any property "inteceptors"
   som_any_prop_getter_t  prop_getter;  // var prop_val = thing.k;
   som_any_prop_setter_t  prop_setter;  // thing.k = prop_val;
-};
+} som_passport_t;
 
 #ifdef CPP11
 

--- a/include/sciter-om.h
+++ b/include/sciter-om.h
@@ -8,22 +8,24 @@ struct som_passport_t;
 
 typedef UINT64 som_atom_t;
 
-struct som_asset_t;
+typedef struct som_asset_t {
+  struct som_asset_class_t* isa;
+} som_asset_t;
 
-struct som_asset_class_t {
+typedef struct som_asset_class_t {
   long(*asset_add_ref)(som_asset_t* thing);
   long(*asset_release)(som_asset_t* thing);
   long(*asset_get_interface)(som_asset_t* thing, const char* name, void** out);
-  som_passport_t* (*asset_get_passport)(som_asset_t* thing);
-};
+  struct som_passport_t* (*asset_get_passport)(som_asset_t* thing);
+} som_asset_class_t;
 
-struct som_asset_t {
-  som_asset_class_t* isa;
-};
-
-inline som_asset_class_t* som_asset_get_class(const som_asset_t* pass)
+inline struct som_asset_class_t* som_asset_get_class(const struct som_asset_t* pass)
 {
+#ifdef __cplusplus
   return pass ? pass->isa : nullptr;
+#else
+  return pass ? pass->isa : NULL;
+#endif
 }
 
 som_atom_t SCAPI SciterAtomValue(const char* name);

--- a/include/sciter-x-api.h
+++ b/include/sciter-x-api.h
@@ -303,6 +303,8 @@ typedef ISciterAPI* (SCAPI *SciterAPI_ptr)();
 
 // getting ISciterAPI reference:
 
+#ifndef CUSTOM_LOADER
+
 #if defined(STATIC_LIB) || defined(SCITER_BUILD)
 
     EXTERN_C ISciterAPI* SCAPI SciterAPI();
@@ -503,7 +505,6 @@ inline ISciterAPI *_SAPI(ISciterAPI *ext) {
 
 #endif
 
-
   inline ISciterAPI* SAPI() {
     static ISciterAPI* _api = _SAPI(NULL);
     return _api;
@@ -518,7 +519,6 @@ inline ISciterAPI *_SAPI(ISciterAPI *ext) {
   {
     return SAPI()->GetSciterRequestAPI();
   }
-
 
   // defining "official" API functions:
 
@@ -717,5 +717,7 @@ inline ISciterAPI *_SAPI(ISciterAPI *ext) {
 
   inline UINT   SCAPI SciterNodeUnwrap(const VALUE* pval, HNODE* ppNode) { return SAPI()->SciterNodeUnwrap(pval, ppNode); }
   inline UINT   SCAPI SciterNodeWrap(VALUE* pval, HNODE pNode) { return SAPI()->SciterNodeWrap(pval, pNode); }
+
+#endif
 
 #endif

--- a/include/sciter-x-behavior.h
+++ b/include/sciter-x-behavior.h
@@ -29,7 +29,7 @@
 
   /** event groups.
        **/
-  enum EVENT_GROUPS
+  typedef enum EVENT_GROUPS
   {
       HANDLE_INITIALIZATION = 0x0000, /**< attached/detached */
       HANDLE_MOUSE = 0x0001,          /**< mouse events */
@@ -55,7 +55,7 @@
       HANDLE_ALL                   = 0xFFFF, /*< all of them */
 
       SUBSCRIPTIONS_REQUEST        = 0xFFFFFFFF, /**< special value for getting subscription flags */
-  };
+  } EVENT_GROUPS;
 
 /**Element callback function for all types of events. Similar to WndProc
  * \param tag \b LPVOID, tag assigned by SciterAttachEventHandler function (like GWL_USERDATA)
@@ -70,48 +70,48 @@ typedef  ElementEventProc * LPElementEventProc;
 // signature of the function exported from external behavior/dll.
 typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEventProc*, LPVOID* );
 
-  enum PHASE_MASK
+  typedef enum PHASE_MASK
   {
       BUBBLING = 0,      // bubbling (emersion) phase
       SINKING  = 0x8000,  // capture (immersion) phase, this flag is or'ed with EVENTS codes below
       HANDLED  = 0x10000
     // see: http://www.w3.org/TR/xml-events/Overview.html#s_intro
-  };
+  } PHASE_MASK;
 
-  enum MOUSE_BUTTONS
+  typedef enum MOUSE_BUTTONS
   {
       MAIN_MOUSE_BUTTON = 1, //aka left button
       PROP_MOUSE_BUTTON = 2, //aka right button
       MIDDLE_MOUSE_BUTTON = 4,
-  };
+  } MOUSE_BUTTONS;
 
-  enum KEYBOARD_STATES
+  typedef enum KEYBOARD_STATES
   {
       CONTROL_KEY_PRESSED = 0x1,
       SHIFT_KEY_PRESSED = 0x2,
       ALT_KEY_PRESSED = 0x4
-  };
+  } KEYBOARD_STATES;
 
 // parameters of evtg == HANDLE_INITIALIZATION
 
-  enum INITIALIZATION_EVENTS
+  typedef enum INITIALIZATION_EVENTS
   {
     BEHAVIOR_DETACH = 0,
     BEHAVIOR_ATTACH = 1
-  };
+  } INITIALIZATION_EVENTS;
 
-  struct INITIALIZATION_PARAMS
+  typedef struct INITIALIZATION_PARAMS
   {
     UINT cmd; // INITIALIZATION_EVENTS
-  };
+  } INITIALIZATION_PARAMS;
 
-  enum SOM_EVENTS
+  typedef enum SOM_EVENTS
   {
     SOM_GET_PASSPORT = 0,
     SOM_GET_ASSET = 1
-  };
+  } SOM_EVENTS;
 
-  struct SOM_PARAMS
+  typedef struct SOM_PARAMS
   {
     UINT cmd; // SOM_EVENTS
     union {
@@ -121,18 +121,18 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
 #ifdef __cplusplus
     SOM_PARAMS() : data() {}
 #endif
-  };
+  } SOM_PARAMS;
 
-  enum DRAGGING_TYPE
+  typedef enum DRAGGING_TYPE
   {
     NO_DRAGGING,
     DRAGGING_MOVE,
     DRAGGING_COPY,
-  };
+  } DRAGGING_TYPE;
 
 // parameters of evtg == HANDLE_MOUSE
 
-  enum MOUSE_EVENTS
+  typedef enum MOUSE_EVENTS
   {
       MOUSE_ENTER = 0,
       MOUSE_LEAVE,
@@ -162,9 +162,9 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
 
       MOUSE_HIT_TEST = 0xFFE,    // sent to element, allows to handle elements with non-trivial shapes. 
 
-  };
+  } MOUSE_EVENTS;
 
-  struct MOUSE_PARAMS
+  typedef struct MOUSE_PARAMS
   {
       UINT      cmd;          // MOUSE_EVENTS
       HELEMENT  target;       // target element
@@ -178,9 +178,9 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
       HELEMENT  dragging;     // element that is being dragged over, this field is not NULL if (cmd & DRAGGING) != 0
       UINT      dragging_mode;// see DRAGGING_TYPE. 
 
-  };
+  } MOUSE_PARAMS;
 
-  enum CURSOR_TYPE
+  typedef enum CURSOR_TYPE
   {
       CURSOR_ARROW, //0
       CURSOR_IBEAM, //1
@@ -198,29 +198,29 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
       CURSOR_HAND,        //13
       CURSOR_DRAG_MOVE,   //14
       CURSOR_DRAG_COPY,   //15
-  };
+  } CURSOR_TYPE;
 
 
 // parameters of evtg == HANDLE_KEY
 
-  enum KEY_EVENTS
+  typedef enum KEY_EVENTS
   {
       KEY_DOWN = 0,
       KEY_UP,
       KEY_CHAR
-  };
+  } KEY_EVENTS;
 
-  struct KEY_PARAMS
+  typedef struct KEY_PARAMS
   {
       UINT      cmd;          // KEY_EVENTS
       HELEMENT  target;       // target element
       UINT      key_code;     // key scan code, or character unicode for KEY_CHAR
       UINT      alt_state;    // KEYBOARD_STATES
-  };
+  } KEY_PARAMS;
 
 
   /** #HANDLE_FOCUS commands */
-  enum FOCUS_EVENTS
+  typedef enum FOCUS_EVENTS
   {
       FOCUS_OUT = 0,            /**< container lost focus from any element inside it, target is an element that lost focus */
       FOCUS_IN = 1,             /**< container got focus on element inside it, target is an element that got focus */
@@ -228,9 +228,9 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
       FOCUS_LOST = 3,           /**< target element lost focus */
       FOCUS_REQUEST = 4,        /**< bubbling event/request, gets sent on child-parent chain to accept/reject focus to be set on the child (target) */
       FOCUS_ADVANCE_REQUEST = 5,/**< bubbling event/request, gets sent on child-parent chain to advance focus */
-  };
+  } FOCUS_EVENTS;
 
-  enum FOCUS_CMD_TYPE {
+  typedef enum FOCUS_CMD_TYPE {
       FOCUS_RQ_NEXT,
       FOCUS_RQ_PREV,
       FOCUS_RQ_HOME,
@@ -242,21 +242,21 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
       FOCUS_RQ_FIRST, // these two - by_code
       FOCUS_RQ_LAST,  //
       FOCUS_RQ_END_REACHED = 0x8000
-  };
+  } FOCUS_CMD_TYPE;
 
   /** #HANDLE_FOCUS params */
-  struct FOCUS_PARAMS
+  typedef struct FOCUS_PARAMS
   {
       UINT      cmd;            /**< #FOCUS_EVENTS */
       HELEMENT  target;         /**< target element, for #FOCUS_LOST it is a handle of new focus element
                                      and for #FOCUS_GOT it is a handle of old focus element, can be NULL */
       UINT      cause;          /**< focus cause params or FOCUS_CMD_TYPE for FOCUS_ADVANCE_REQUEST */
       SBOOL      cancel;         /**< in #FOCUS_REQUEST and #FOCUS_LOST phase setting this field to true will cancel transfer focus from old element to the new one. */
-  };
+  } FOCUS_PARAMS;
 
 // parameters of evtg == HANDLE_SCROLL
 
-  enum SCROLL_EVENTS
+  typedef enum SCROLL_EVENTS
   {
     SCROLL_HOME = 0,
     SCROLL_END,
@@ -272,17 +272,17 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
 
     SCROLL_ANIMATION_START,
     SCROLL_ANIMATION_END,
-  };
+  } SCROLL_EVENTS;
 
-  enum SCROLL_SOURCE {
+  typedef enum SCROLL_SOURCE {
     SCROLL_SOURCE_UNKNOWN,
     SCROLL_SOURCE_KEYBOARD,  // SCROLL_PARAMS::reason <- keyCode
     SCROLL_SOURCE_SCROLLBAR, // SCROLL_PARAMS::reason <- SCROLLBAR_PART 
     SCROLL_SOURCE_ANIMATOR,
     SCROLL_SOURCE_WHEEL,
-  };
+  } SCROLL_SOURCE;
 
-  enum SCROLLBAR_PART {
+  typedef enum SCROLLBAR_PART {
     SCROLLBAR_BASE,       
     SCROLLBAR_PLUS,       
     SCROLLBAR_MINUS,      
@@ -290,10 +290,10 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     SCROLLBAR_PAGE_MINUS, 
     SCROLLBAR_PAGE_PLUS,  
     SCROLLBAR_CORNER,     
-  };
+  } SCROLLBAR_PART;
 
 
-  struct SCROLL_PARAMS
+  typedef struct SCROLL_PARAMS
   {
       UINT      cmd;          // SCROLL_EVENTS
       HELEMENT  target;       // target element
@@ -301,9 +301,9 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
       SBOOL      vertical;     // true if from vertical scrollbar
       UINT      source;       // SCROLL_SOURCE
       UINT      reason;       // key or scrollbar part
-  };
+  } SCROLL_PARAMS;
 
-  enum GESTURE_CMD
+  typedef enum GESTURE_CMD
   {
     GESTURE_START = 0,
     GESTURE_MOVE = 1,
@@ -316,15 +316,16 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     GESTURE_TAP1,   // The tap gesture, a.k.a. click
     GESTURE_TAP2,   // The two-finger tap gesture, a.k.a. right-click
     GESTURE_DOUBLE_TAP
-  };
-  enum GESTURE_STATE 
+  } GESTURE_CMD;
+
+  typedef enum GESTURE_STATE 
   {
     GESTURE_STATE_BEGIN   = 1, // starts
     GESTURE_STATE_INERTIA = 2, // events generated by inertia processor
     GESTURE_STATE_END     = 4, // end, last event of the gesture sequence
-  };
+  } GESTURE_STATE;
 
-  enum GESTURE_TYPE_FLAGS // requested 
+  typedef enum GESTURE_TYPE_FLAGS // requested 
   {
     GESTURE_FLAG_ZOOM               = 0x0001,
     GESTURE_FLAG_ROTATE             = 0x0002,
@@ -336,9 +337,9 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     GESTURE_FLAG_PAN_WITH_GUTTER    = 0x4000, // PAN_VERTICAL and PAN_HORIZONTAL modifiers
     GESTURE_FLAG_PAN_WITH_INERTIA   = 0x8000, //
     GESTURE_FLAGS_ALL               = 0xFFFF, //
-  };
+  } GESTURE_TYPE_FLAGS;
 
-  struct GESTURE_PARAMS
+  typedef struct GESTURE_PARAMS
   {
     UINT      cmd;          // GESTURE_EVENTS
     HELEMENT  target;       // target element
@@ -350,9 +351,9 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     SIZE      delta_xy;     // for GESTURE_PAN it is a direction vector 
     double    delta_v;      // for GESTURE_ROTATE - delta angle (radians) 
                             // for GESTURE_ZOOM - zoom value, is less or greater than 1.0    
-  };
+  } GESTURE_PARAMS;
 
-  enum EXCHANGE_CMD {
+  typedef enum EXCHANGE_CMD {
     X_DRAG_ENTER = 0,       // drag enters the element
     X_DRAG_LEAVE = 1,       // drag leaves the element  
     X_DRAG = 2,             // drag over the element
@@ -361,17 +362,17 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     X_DRAG_REQUEST = 5,     // N/A
     X_DRAG_CANCEL = 6,      // drag cancelled (e.g. by pressing VK_ESCAPE)
     X_WILL_ACCEPT_DROP = 7, // drop target element shall consume this event in order to receive X_DROP 
-  };
+  } EXCHANGE_CMD;
 
-  enum DD_MODES {
+  typedef enum DD_MODES {
     DD_MODE_NONE = 0, // DROPEFFECT_NONE	( 0 )
     DD_MODE_COPY = 1, // DROPEFFECT_COPY	( 1 )
     DD_MODE_MOVE = 2, // DROPEFFECT_MOVE	( 2 )
     DD_MODE_COPY_OR_MOVE = 3, // DROPEFFECT_COPY	( 1 ) | DROPEFFECT_MOVE	( 2 )
     DD_MODE_LINK = 4, // DROPEFFECT_LINK	( 4 )
-  };
+  } DD_MODES;
   
-  struct EXCHANGE_PARAMS
+  typedef struct EXCHANGE_PARAMS
   {
     UINT         cmd;          // EXCHANGE_EVENTS
     HELEMENT     target;       // target element
@@ -380,34 +381,34 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     POINT        pos_view;     // position of cursor, view relative
     UINT         mode;         // DD_MODE 
     SCITER_VALUE data;         // packaged drag data
-  };
+  } EXCHANGE_PARAMS;
 
 
-  enum DRAW_EVENTS
+  typedef enum DRAW_EVENTS
   {
       DRAW_BACKGROUND = 0,
       DRAW_CONTENT = 1,
       DRAW_FOREGROUND = 2,
       DRAW_OUTLINE = 3,
-  };
+  } DRAW_EVENTS;
 
   typedef struct SCITER_GRAPHICS SCITER_GRAPHICS;
 
-  struct DRAW_PARAMS
+  typedef struct DRAW_PARAMS
   {
       UINT             cmd;       // DRAW_EVENTS
       HGFX             gfx;       // hdc to paint on
       RECT             area;      // element area, to get invalid area to paint use GetClipBox,
       UINT             reserved;  // for DRAW_BACKGROUND/DRAW_FOREGROUND - it is a border box
                                   // for DRAW_CONTENT - it is a content box
-  };
+  } DRAW_PARAMS;
 
-  enum CONTENT_CHANGE_BITS {  // for CONTENT_CHANGED reason
+  typedef enum CONTENT_CHANGE_BITS {  // for CONTENT_CHANGED reason
      CONTENT_ADDED = 0x01,
      CONTENT_REMOVED = 0x02,
-  };
+  } CONTENT_CHANGE_BITS;
 
-  enum BEHAVIOR_EVENTS
+  typedef enum BEHAVIOR_EVENTS
   {
       BUTTON_CLICK = 0,              // click on button
       BUTTON_PRESS = 1,              // mouse down or key down in button
@@ -514,24 +515,24 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
       // To send event notifications with  these codes use
       // SciterSend/PostEvent API.
 
-  };
+  } BEHAVIOR_EVENTS;
 
-  enum CLICK_REASON
+  typedef enum CLICK_REASON
   {
       BY_MOUSE_CLICK,
       BY_KEY_CLICK,
       SYNTHESIZED,       // synthesized, programmatically generated.
       BY_MOUSE_ON_ICON,  
-  };
+  } CLICK_REASON;
 
-  enum EDIT_CHANGED_REASON
+  typedef enum EDIT_CHANGED_REASON
   {
       BY_INS_CHAR,  // single char insertion
       BY_INS_CHARS, // character range insertion, clipboard
       BY_DEL_CHAR,  // single char deletion
       BY_DEL_CHARS, // character range deletion (selection)
       BY_UNDO_REDO, // undo/redo
-  };
+  } EDIT_CHANGED_REASON;
 
   typedef struct BEHAVIOR_EVENT_PARAMS
   {
@@ -558,7 +559,7 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
   // identifiers of methods currently supported by intrinsic behaviors,
   // see function SciterCallBehaviorMethod
 
-  enum BEHAVIOR_METHOD_IDENTIFIERS
+  typedef enum BEHAVIOR_METHOD_IDENTIFIERS
   {
     DO_CLICK = 0,
 /*  remnants of HTMLayout API, not used 
@@ -592,7 +593,7 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
     SET_VALUE     = 0xFE,       // p - VALUE_PARAMS  
 
     FIRST_APPLICATION_METHOD_ID = 0x100
-  };
+  } BEHAVIOR_METHOD_IDENTIFIERS;
 
   typedef struct SCRIPTING_METHOD_PARAMS
   {
@@ -603,24 +604,24 @@ typedef SBOOL SC_CALLBACK SciterBehaviorFactory( LPCSTR, HELEMENT, LPElementEven
   } SCRIPTING_METHOD_PARAMS;
 
   // GET_VALUE/SET_VALUE methods params
-  struct VALUE_PARAMS 
+  typedef struct VALUE_PARAMS 
   {
     UINT         methodID;
     SCITER_VALUE val;
 #ifdef __cplusplus
     VALUE_PARAMS(bool do_set) { methodID = do_set? SET_VALUE : GET_VALUE; }
 #endif
-  };
+  } VALUE_PARAMS;
 
   // IS_EMPTY method params
-  struct IS_EMPTY_PARAMS
+  typedef struct IS_EMPTY_PARAMS
   {
     UINT methodID;
     UINT is_empty; // !0 - is empty
 #ifdef __cplusplus
     IS_EMPTY_PARAMS():is_empty(0) { methodID = IS_EMPTY; }
 #endif
-  };
+  } IS_EMPTY_PARAMS;
 
   // see SciterRequestElementData
 

--- a/include/sciter-x-def.h
+++ b/include/sciter-x-def.h
@@ -444,15 +444,15 @@ typedef SCN_INVALIDATE_RECT *LPSCN_INVALIDATE_RECT;
  *
  **/
 
-enum SCRIPT_RUNTIME_FEATURES
+typedef enum SCRIPT_RUNTIME_FEATURES
 {
   ALLOW_FILE_IO = 0x00000001,
   ALLOW_SOCKET_IO = 0x00000002,
   ALLOW_EVAL = 0x00000004,
   ALLOW_SYSINFO = 0x00000008
-};
+} SCRIPT_RUNTIME_FEATURES;
 
-enum SCITER_RT_OPTIONS
+typedef enum SCITER_RT_OPTIONS
 {
    SCITER_SMOOTH_SCROLL = 1,      // value:TRUE - enable, value:FALSE - disable, enabled by default
    SCITER_CONNECTION_TIMEOUT = 2, // value: milliseconds, connection timeout of http client
@@ -482,7 +482,7 @@ enum SCITER_RT_OPTIONS
 
    SCITER_SET_PX_AS_DIP = 16, // value 1 - 1px in CSS is treated as 1dip, value 0 - default behavior - 1px is a physical pixel 
 
-};
+} SCITER_RT_OPTIONS;
 
  SBOOL SCAPI SciterSetOption(HWINDOW hWnd, UINT option, UINT_PTR value );
 
@@ -601,7 +601,7 @@ SBOOL SCAPI SciterRenderOnDirectXTexture(HWINDOW hwnd, HELEMENT elementToRenderO
  *
  **/
 
- SBOOL SCAPI     SciterDWFactory(void** /*IDWriteFactory ***/ ppf);
+ SBOOL SCAPI     SciterDWFactory(IUnknown** /*IDWriteFactory ***/ ppf);
 
 #endif
 
@@ -640,7 +640,7 @@ SBOOL SCAPI SciterRenderOnDirectXTexture(HWINDOW hwnd, HELEMENT elementToRenderO
   typedef LPVOID SciterWindowDelegate;
 #endif
 
-enum SCITER_CREATE_WINDOW_FLAGS {
+typedef enum SCITER_CREATE_WINDOW_FLAGS {
    SW_CHILD      = (1 << 0), // child window only, if this flag is set all other flags ignored
    SW_TITLEBAR   = (1 << 1), // toplevel window, has titlebar
    SW_RESIZEABLE = (1 << 2), // has resizeable frame
@@ -652,7 +652,7 @@ enum SCITER_CREATE_WINDOW_FLAGS {
    SW_POPUP      = (1 << 8), // the window is created as topmost window.
    SW_ENABLE_DEBUG = (1 << 9), // make this window inspector ready
    SW_OWNS_VM      = (1 << 10), // it has its own script VM
-};
+} SCITER_CREATE_WINDOW_FLAGS;
 
 #if !defined(WINDOWLESS)
 /** Create sciter window.
@@ -681,19 +681,20 @@ enum SCITER_CREATE_WINDOW_FLAGS {
  *
  **/
 
-enum OUTPUT_SUBSYTEMS
+typedef enum OUTPUT_SUBSYTEMS
 {
    OT_DOM = 0,       // html parser & runtime
    OT_CSSS,          // csss! parser & runtime
    OT_CSS,           // css parser
    OT_TIS,           // TIS parser & runtime
-};
-enum OUTPUT_SEVERITY
+} OUTPUT_SUBSYTEMS;
+
+typedef enum OUTPUT_SEVERITY
 {
   OS_INFO,
   OS_WARNING,
   OS_ERROR,
-};
+} OUTPUT_SEVERITY;
 
 typedef VOID (SC_CALLBACK* DEBUG_OUTPUT_PROC)(LPVOID param, UINT subsystem /*OUTPUT_SUBSYTEMS*/, UINT severity, LPCWSTR text, UINT text_length);
 

--- a/include/sciter-x-dom.h
+++ b/include/sciter-x-dom.h
@@ -313,7 +313,7 @@ SCDOM_RESULT SCAPI SciterSetStyleAttribute(HELEMENT he, LPCSTR name, LPCWSTR val
  * \return \b #SCDOM_RESULT SCAPI
  **/
 
-enum ELEMENT_AREAS
+typedef enum ELEMENT_AREAS
 {
   ROOT_RELATIVE = 0x01,       // - or this flag if you want to get Sciter window relative coordinates,
                               //   otherwise it will use nearest windowed container e.g. popup window.
@@ -332,15 +332,15 @@ enum ELEMENT_AREAS
 
   SCROLLABLE_AREA = 0x60,   // scroll_area - scrollable area in content box
 
-};
+} ELEMENT_AREAS;
 
 SCDOM_RESULT SCAPI SciterGetElementLocation(HELEMENT he, LPRECT p_location, UINT areas /*ELEMENT_AREAS*/);
 
-enum SCITER_SCROLL_FLAGS
+typedef enum SCITER_SCROLL_FLAGS
 {
   SCROLL_TO_TOP = 0x01,
   SCROLL_SMOOTH = 0x10,
-};
+} SCITER_SCROLL_FLAGS;
 
 /*Scroll to view.
  * \param[in] he \b #HELEMENT
@@ -456,7 +456,7 @@ SCDOM_RESULT SCAPI SciterSelectParentW(
           /*out*/ HELEMENT* heFound);
 
 
-enum SET_ELEMENT_HTML
+typedef enum SET_ELEMENT_HTML
 {
   SIH_REPLACE_CONTENT     = 0,
   SIH_INSERT_AT_START     = 1,
@@ -464,7 +464,7 @@ enum SET_ELEMENT_HTML
   SOH_REPLACE             = 3,
   SOH_INSERT_BEFORE       = 4,
   SOH_INSERT_AFTER        = 5
-};
+} SET_ELEMENT_HTML;
 
 /**Set inner or outer html of the element.
  * \param[in] he \b #HELEMENT
@@ -558,7 +558,7 @@ SCDOM_RESULT SCAPI SciterHidePopup(HELEMENT he);
 typedef SBOOL SC_CALLBACK ElementEventProc(LPVOID tag, HELEMENT he, UINT evtg, LPVOID prms );
 typedef ElementEventProc* LPELEMENT_EVENT_PROC;
 
-enum ELEMENT_STATE_BITS
+typedef enum ELEMENT_STATE_BITS
 {
    STATE_LINK             = 0x00000001,  // :link pseudo-class in CSS
    STATE_HOVER            = 0x00000002,  // :hover pseudo-class in CSS
@@ -596,7 +596,7 @@ enum ELEMENT_STATE_BITS
    STATE_IS_LTR           = 0x10000000,  // the element or one of its containers has dir=ltr declared
    STATE_IS_RTL           = 0x20000000,  // the element or one of its containers has dir=rtl declared
 
-};
+} ELEMENT_STATE_BITS;
 
   /** Get/set state bits, stateBits*** accept or'ed values above
    **/
@@ -736,13 +736,13 @@ SCDOM_RESULT SCAPI SciterRequestElementData(
  *
  **/
 
-enum REQUEST_TYPE
+typedef enum REQUEST_TYPE
 {
   GET_ASYNC,  // async GET
   POST_ASYNC, // async POST
   GET_SYNC,   // synchronous GET
   POST_SYNC   // synchronous POST
-};
+} REQUEST_TYPE;
 
 //struct REQUEST_PARAM { LPCWSTR name; LPCWSTR value; };
 

--- a/include/sciter-x-types.h
+++ b/include/sciter-x-types.h
@@ -122,6 +122,8 @@ enum GFX_LAYER
     #define TARGET_32
   #endif
 
+  #define SCITER_DLL_NAME "sciter.dll"
+
 #elif defined(OSX)
 
   //#ifdef __OBJC__

--- a/include/value.h
+++ b/include/value.h
@@ -3,13 +3,13 @@
 
 #include "sciter-x-types.h"
 
-enum VALUE_RESULT
+typedef enum VALUE_RESULT
 {
   HV_OK_TRUE = -1,
   HV_OK = 0,
   HV_BAD_PARAMETER = 1,
   HV_INCOMPATIBLE_TYPE = 2
-};
+} VALUE_RESULT;
 
 typedef struct
 {
@@ -20,7 +20,7 @@ typedef struct
 
 #define FLOAT_VALUE   double
 
-enum VALUE_TYPE
+typedef enum VALUE_TYPE
 {
     T_UNDEFINED = 0,
     T_NULL = 1,
@@ -43,11 +43,9 @@ enum VALUE_TYPE
     T_ANGLE = 18,      // double, radians
     T_COLOR = 19,      // [unsigned] INT, ABGR
     T_ASSET = 21,      // sciter::om::iasset* add_ref'ed pointer
+} VALUE_TYPE;
 
-
-};
-
-enum VALUE_UNIT_TYPE
+typedef enum VALUE_UNIT_TYPE
 {
     UT_EM = 1, //height of the element's font. 
     UT_EX = 2, //height of letter 'x' 
@@ -65,18 +63,18 @@ enum VALUE_UNIT_TYPE
     reserved3 = 14, 
     reserved4 = 15, 
     UT_URL   = 16,  // url in string
-};
+} VALUE_UNIT_TYPE;
 
-enum VALUE_UNIT_TYPE_DATE
+typedef enum VALUE_UNIT_TYPE_DATE
 {
     DT_HAS_DATE         = 0x01, // date contains date portion
     DT_HAS_TIME         = 0x02, // date contains time portion HH:MM
     DT_HAS_SECONDS      = 0x04, // date contains time and seconds HH:MM:SS
     DT_UTC              = 0x10, // T_DATE is known to be UTC. Otherwise it is local date/time
-};
+} VALUE_UNIT_TYPE_DATE;
 
 // Sciter or TIScript specific
-enum VALUE_UNIT_TYPE_OBJECT
+typedef enum VALUE_UNIT_TYPE_OBJECT
 {
     UT_OBJECT_ARRAY  = 0,   // type T_OBJECT of type Array
     UT_OBJECT_OBJECT = 1,   // type T_OBJECT of type Object
@@ -84,20 +82,20 @@ enum VALUE_UNIT_TYPE_OBJECT
     UT_OBJECT_NATIVE = 3,   // type T_OBJECT of native Type with data slot (LPVOID)
     UT_OBJECT_FUNCTION = 4, // type T_OBJECT of type Function
     UT_OBJECT_ERROR = 5,    // type T_OBJECT of type Error
-};
+} VALUE_UNIT_TYPE_OBJECT;
 
-enum VALUE_UNIT_UNDEFINED {
+typedef enum VALUE_UNIT_UNDEFINED {
   UT_NOTHING = 1 // T_UNDEFINED && UT_NOTHING -  'nothing' a.k.a. 'void' value in script 
-};
+} VALUE_UNIT_UNDEFINED;
 
 // Sciter or TIScript specific
-enum VALUE_UNIT_TYPE_STRING
+typedef enum VALUE_UNIT_TYPE_STRING
 {
     UT_STRING_STRING = 0,        // string
     UT_STRING_ERROR  = 1,        // is an error string
     UT_STRING_SECURE = 2,        // secure string ("wiped" on destroy)
     UT_STRING_SYMBOL = 0xffff,   // symbol in tiscript sense
-};
+} VALUE_UNIT_TYPE_STRING;
 
 // Native functor
 typedef VOID NATIVE_FUNCTOR_INVOKE( VOID* tag, UINT argc, const VALUE* argv, VALUE* retval); // retval may contain error definition
@@ -254,14 +252,13 @@ UINT SCAPI ValueSetValueToKey( VALUE* pval, const VALUE* pkey, const VALUE* pval
  */
 UINT SCAPI ValueGetValueOfKey( const VALUE* pval, const VALUE* pkey, VALUE* pretval);
 
-enum VALUE_STRING_CVT_TYPE
+typedef enum VALUE_STRING_CVT_TYPE
 {
   CVT_SIMPLE,        ///< simple conversion of terminal values 
   CVT_JSON_LITERAL,  ///< json literal parsing/emission 
   CVT_JSON_MAP,      ///< json parsing/emission, it parses as if token '{' already recognized 
-  CVT_XJSON_LITERAL, ///< x-json parsing/emission, date is emitted as ISO8601 date literal, currency is emitted in the form DDDD$CCC
-                                                   
-};
+  CVT_XJSON_LITERAL, ///< x-json parsing/emission, date is emitted as ISO8601 date literal, currency is emitted in the form DDDD$CCC                                           
+} VALUE_STRING_CVT_TYPE;
 
 /**
  * ValueToString - converts value to T_STRING inplace:


### PR DESCRIPTION
While testing if Sciter JS fits the needs of a rust project, and testing the bindings in rust and encountering many stability issues. I tried regenerating the bindings to the C API.

* Added a CUSTOM_LOADER define to remove the loading code from the Api header as the section doesn't compile in strict C mode
* Added typedefs to the enums and structs so they get generated when the are not referenced directly.
* FIxed a discrepency in a Function using void* instread of IUnknown.

I will publish a crate with the auto bindings for reference.
