### PR TITLE
More idiomatic and less buggy form change example

### DIFF
--- a/docs/md/behaviors/behavior-form.md
+++ b/docs/md/behaviors/behavior-form.md
@@ -125,8 +125,11 @@ name/value map - object in script terms with names corresponding to name attribu
 ### `on()` subscription
 
 ```JavaScript
-var frm = document.$("form#some");
-frm.on("change", function() { var formValue = this.value; ... });
-document.on("change", "form#some", function(evt, form) { var formValue = form.value; ... });
+document.body.on('change', 'form', ({ target: form }) => {
+   const { value } = form;
+   const json = JSON.stringify(value, null, 2);
+   console.log(json);
+   Window.this.modal(<info>{json}</info>);
+});
 ```
 


### PR DESCRIPTION
This code is what I've found myself having to use in an actual project, because the original example triggers the event twice in practice which is very unexpected and undesirable.

Also, why `var` in 2021?