### PR TITLE
Quote pre-build command and arguments

### DIFF
--- a/build/windows/glfw-opengl.vcxproj
+++ b/build/windows/glfw-opengl.vcxproj
@@ -119,7 +119,7 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos.lite\facade $(ProjectDir)..\..\demos.lite\facade-resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos.lite\facade" "$(ProjectDir)..\..\demos.lite\facade-resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -145,7 +145,7 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos.lite\facade $(ProjectDir)..\..\demos.lite\facade-resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos.lite\facade" "$(ProjectDir)..\..\demos.lite\facade-resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -176,7 +176,7 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos.lite\facade $(ProjectDir)..\..\demos.lite\facade-resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos.lite\facade" "$(ProjectDir)..\..\demos.lite\facade-resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -207,7 +207,7 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos.lite\facade $(ProjectDir)..\..\demos.lite\facade-resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos.lite\facade" "$(ProjectDir)..\..\demos.lite\facade-resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/build/windows/inspector.vcxproj
+++ b/build/windows/inspector.vcxproj
@@ -166,7 +166,7 @@
       <AdditionalManifestFiles>../../demos/inspector/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\inspector\res $(ProjectDir)..\..\demos\inspector\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\inspector\res" "$(ProjectDir)..\..\demos\inspector\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -196,7 +196,7 @@
       <AdditionalManifestFiles>../../demos/inspector/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\inspector\res $(ProjectDir)..\..\demos\inspector\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\inspector\res" "$(ProjectDir)..\..\demos\inspector\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -226,7 +226,7 @@
       <AdditionalManifestFiles>../../demos/inspector/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\inspector\res $(ProjectDir)..\..\demos\inspector\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\inspector\res" "$(ProjectDir)..\..\demos\inspector\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -261,7 +261,7 @@
       <AdditionalManifestFiles>../../demos/inspector/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\inspector\res $(ProjectDir)..\..\demos\inspector\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\inspector\res" "$(ProjectDir)..\..\demos\inspector\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -296,7 +296,7 @@
       <AdditionalManifestFiles>../../demos/inspector/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\inspector\res $(ProjectDir)..\..\demos\inspector\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\inspector\res" "$(ProjectDir)..\..\demos\inspector\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -331,7 +331,7 @@
       <AdditionalManifestFiles>../../demos/inspector/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\inspector\res $(ProjectDir)..\..\demos\inspector\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\inspector\res" "$(ProjectDir)..\..\demos\inspector\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/build/windows/integration.vcxproj
+++ b/build/windows/integration.vcxproj
@@ -125,7 +125,7 @@
       <AdditionalManifestFiles>../../demos/integration/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\integration\res $(ProjectDir)..\..\demos\integration\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\integration\res" "$(ProjectDir)..\..\demos\integration\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -155,7 +155,7 @@
       <AdditionalManifestFiles>../../demos/integration/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\integration\res $(ProjectDir)..\..\demos\integration\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\integration\res" "$(ProjectDir)..\..\demos\integration\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -190,7 +190,7 @@
       <AdditionalManifestFiles>../../demos/integration/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\integration\res $(ProjectDir)..\..\demos\integration\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\integration\res" "$(ProjectDir)..\..\demos\integration\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -225,7 +225,7 @@
       <AdditionalManifestFiles>../../demos/integration/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\integration\res $(ProjectDir)..\..\demos\integration\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\integration\res" "$(ProjectDir)..\..\demos\integration\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/build/windows/usciter.vcxproj
+++ b/build/windows/usciter.vcxproj
@@ -291,7 +291,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -321,7 +321,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -351,7 +351,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -386,7 +386,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -421,7 +421,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -456,7 +456,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugSkia|Win32'">
@@ -486,7 +486,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugSkia|x64'">
@@ -516,7 +516,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugSkia|ARM64'">
@@ -546,7 +546,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSkia|Win32'">
@@ -581,7 +581,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSkia|x64'">
@@ -616,7 +616,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseSkia|ARM64'">
@@ -651,7 +651,7 @@
       <AdditionalManifestFiles>../../demos/usciter/win-res/dpi-aware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
     <PreBuildEvent>
-      <Command>$(ProjectDir)..\..\bin\windows\packfolder.exe $(ProjectDir)..\..\demos\usciter\res $(ProjectDir)..\..\demos\usciter\resources.cpp -v "resources"</Command>
+      <Command>"$(ProjectDir)..\..\bin\windows\packfolder.exe" "$(ProjectDir)..\..\demos\usciter\res" "$(ProjectDir)..\..\demos\usciter\resources.cpp" -v "resources"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/premake5.lua
+++ b/premake5.lua
@@ -146,7 +146,7 @@ project "usciter"
            "demos/usciter/win-res/dpi-aware.manifest" }
     links { "shell32", "advapi32", "ole32", "oleaut32", "gdi32", "comdlg32" }
     prebuildcommands { 
-      "%{prj.location}..\\..\\bin\\".. osabbr() .. "\\packfolder.exe %{prj.location}..\\..\\demos\\usciter\\res %{prj.location}..\\..\\demos\\usciter\\resources.cpp -v \"resources\""
+      "\"%{prj.location}..\\..\\bin\\".. osabbr() .. "\\packfolder.exe\" \"%{prj.location}..\\..\\demos\\usciter\\res\" \"%{prj.location}..\\..\\demos\\usciter\\resources.cpp\" -v \"resources\""
     }
 
   filter "system:macosx"
@@ -188,7 +188,7 @@ project "inspector"
            "demos/inspector/win-res/inspector.rc",
            "demos/inspector/win-res/dpi-aware.manifest" }
     prebuildcommands { 
-      "%{prj.location}..\\..\\bin\\".. osabbr() .. "\\packfolder.exe %{prj.location}..\\..\\demos\\inspector\\res %{prj.location}..\\..\\demos\\inspector\\resources.cpp -v \"resources\""
+      "\"%{prj.location}..\\..\\bin\\".. osabbr() .. "\\packfolder.exe\" \"%{prj.location}..\\..\\demos\\inspector\\res\" \"%{prj.location}..\\..\\demos\\inspector\\resources.cpp\" -v \"resources\""
     }
 
   filter "system:macosx"
@@ -231,7 +231,7 @@ project "integration"
            "demos/integration/win-res/integration.rc",
            "demos/integration/win-res/dpi-aware.manifest" }
     prebuildcommands { 
-      "%{prj.location}..\\..\\bin\\".. osabbr() .. "\\packfolder.exe %{prj.location}..\\..\\demos\\integration\\res %{prj.location}..\\..\\demos\\integration\\resources.cpp -v \"resources\""
+      "\"%{prj.location}..\\..\\bin\\".. osabbr() .. "\\packfolder.exe\" \"%{prj.location}..\\..\\demos\\integration\\res\" \"%{prj.location}..\\..\\demos\\integration\\resources.cpp\" -v \"resources\""
     }
 
   filter "system:macosx"
@@ -337,7 +337,7 @@ project "glfw-opengl"
 
   configuration "windows"
     prebuildcommands { 
-      "%{prj.location}..\\..\\bin\\windows\\packfolder.exe %{prj.location}..\\..\\demos.lite\\facade %{prj.location}..\\..\\demos.lite\\facade-resources.cpp -v \"resources\""
+      "\"%{prj.location}..\\..\\bin\\windows\\packfolder.exe\" \"%{prj.location}..\\..\\demos.lite\\facade\" \"%{prj.location}..\\..\\demos.lite\\facade-resources.cpp\" -v \"resources\""
     }
   configuration {}
 


### PR DESCRIPTION
This fixes windows build in case `$(ProjectDir)` contains white spaces