### PR TITLE
fix: reactor form sample

### DIFF
--- a/samples.sciter/reactor-form/form.htm
+++ b/samples.sciter/reactor-form/form.htm
@@ -33,20 +33,20 @@ document.body.append(
     <Form #theform value={initialValue} validate={validate}>
       <label>email</label>
         <input|text(email) />
-          <FormError(email) />
+          <FormError key="email" />
       
       <label>password</label>
         <input|password(password) />
-          <FormError(password) />
+          <FormError key="password" />
       
       <label>sex</label>
          <group><button(sex)|radio value="male">Male</button>
                 <button(sex)|radio value="female">Female</button></group>
-           <FormError(sex) />
+           <FormError key="sex" />
       
       <label>description</label>
          <textarea(description) />  
-           <FormError(description) />
+           <FormError key="description" />
 
       <button|submit>Submit</button>
     </Form>);

--- a/samples.sciter/reactor-form/form.js
+++ b/samples.sciter/reactor-form/form.js
@@ -1,7 +1,7 @@
 ﻿
 
 export function FormError(props) {
-  const name = props.name;
+  const name = props.key;
   const error = Form.instance.errors?.[name]; 
   if( error ) 
     return <div.error for={name}>⇐ {error}</div>;


### PR DESCRIPTION
Using `name` field in `<FormError/>` like `<FormError (email) />` conflicts with name of actual input inside the form giving erroneous value for the form this commit fixes it by using `key` prop instead of name in <FormError> component. 

