### PR TITLE
Fixed Inspector `val.toString()` issue

### DIFF
--- a/demos/inspector/res/value.js
+++ b/demos/inspector/res/value.js
@@ -120,7 +120,7 @@ function crackText(text) {
 }
 
 export function SublimatedValue(channel, val, key, forLog = false) {
-  if (!key) key = val.toString();
+  if (!key) key = `${val}`;
 
   if (val === null)
     return <var .null key={key}>null</var>;


### PR DESCRIPTION
If you evaluated something in the Inspector that returned `undefined`, it would throw an error saying:
```
TypeError: cannot read property 'toString' of undefined
```
This is because it tries to call `.toString()` on any returned value. You cannot call `.toString()` on `undefined`. To fix this, I wrapped the `val` in a template literal to handle the conversion to string for us.